### PR TITLE
Add MercadoPago routes

### DIFF
--- a/modules/MercadoPago/Routes/web.php
+++ b/modules/MercadoPago/Routes/web.php
@@ -1,0 +1,12 @@
+<?php
+use Illuminate\Support\Facades\Route;
+use Modules\MercadoPago\Http\Controllers\SettingsController;
+
+Route::middleware('auth')
+    ->prefix('mercadopago')
+    ->group(function () {
+        Route::get('settings', [SettingsController::class, 'index'])
+            ->name('mercadopago.settings');
+        Route::post('settings', [SettingsController::class, 'save'])
+            ->name('mercadopago.settings.save');
+    });


### PR DESCRIPTION
## Summary
- add `web.php` for MercadoPago routes

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684763c8a4d4832ab8706308742ae3c8