### PR TITLE
Add basic MercadoPago settings view

### DIFF
--- a/modules/MercadoPago/Resources/Views/settings.blade.php
+++ b/modules/MercadoPago/Resources/Views/settings.blade.php
@@ -1,0 +1,10 @@
+<form method="POST" action="{{ route('mercadopago.settings.save') }}">
+    @csrf
+    <label>{{ __('Access Token') }}</label>
+    <input type="text" name="mercadopago_access_token" value="{{ $token ?? '' }}">
+
+    <label>{{ __('Device ID') }}</label>
+    <input type="text" name="mercadopago_device_id" value="{{ $device_id ?? '' }}">
+
+    <button type="submit">{{ __('Save') }}</button>
+</form>


### PR DESCRIPTION
## Summary
- add MercadoPago settings form view

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684763ce7090832aa87995554cbb2cc2