### PR TITLE
Add MercadoPago menu service provider

### DIFF
--- a/modules/MercadoPago/Providers/MenuServiceProvider.php
+++ b/modules/MercadoPago/Providers/MenuServiceProvider.php
@@ -1,0 +1,20 @@
+<?php
+namespace Modules\MercadoPago\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use TorMorten\Eventy\Facades\Events as Hook;
+
+class MenuServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        Hook::addFilter('ns-dashboard-menus', function ($menus) {
+            $menus['mercadopago'] = [
+                'label' => __('Mercado Pago'),
+                'icon'  => 'la-credit-card',
+                'href'  => ns()->route('mercadopago.settings'),
+            ];
+            return $menus;
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add a service provider hooking into dashboard menus for MercadoPago module

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684763d09348832a97e355a6db11347b