### PR TITLE
Add MercadoPago callback handler

### DIFF
--- a/database/migrations/create/2024_08_30_000000_create_mercadopago_transactions_table.php
+++ b/database/migrations/create/2024_08_30_000000_create_mercadopago_transactions_table.php
@@ -1,0 +1,20 @@
+<?php
+use App\Classes\Schema;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+return new class extends Migration {
+    public function up() {
+        Schema::createIfMissing('nexopos_mercadopago_transactions', function (Blueprint $table) {
+            $table->id();
+            $table->string('payment_id');
+            $table->string('status');
+            $table->text('payload')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down() {
+        Schema::dropIfExists('nexopos_mercadopago_transactions');
+    }
+};

--- a/modules/MercadoPago/Http/Controllers/CallbackController.php
+++ b/modules/MercadoPago/Http/Controllers/CallbackController.php
@@ -1,0 +1,50 @@
+<?php
+namespace Modules\MercadoPago\Http\Controllers;
+
+use App\Models\Order;
+use App\Services\OrdersService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use MercadoPago\Client\Payment\PaymentClient;
+use MercadoPago\MercadoPagoConfig;
+use Modules\MercadoPago\Models\MercadoPagoTransaction;
+
+class CallbackController
+{
+    public function handle(Request $request)
+    {
+        $paymentId = data_get($request->input('data'), 'id');
+
+        if (! $paymentId) {
+            return response()->json(['status' => 'ignored']);
+        }
+
+        MercadoPagoConfig::setAccessToken(config('mercadopago.access_token'));
+        $client = new PaymentClient();
+
+        try {
+            $payment = $client->get($paymentId);
+        } catch (\Throwable $e) {
+            Log::error('MercadoPago callback error: ' . $e->getMessage());
+
+            return response()->json(['status' => 'error'], 400);
+        }
+
+        MercadoPagoTransaction::create([
+            'payment_id' => $payment->id,
+            'status' => $payment->status,
+            'payload' => json_encode($payment),
+        ]);
+
+        $order = Order::where('code', $payment->external_reference)->first();
+
+        if ($order) {
+            app()->make(OrdersService::class)->makeOrderSinglePayment([
+                'identifier' => 'mercadopago',
+                'value' => $payment->transaction_amount,
+            ], $order);
+        }
+
+        return response()->json(['status' => $payment->status]);
+    }
+}

--- a/modules/MercadoPago/Models/MercadoPagoTransaction.php
+++ b/modules/MercadoPago/Models/MercadoPagoTransaction.php
@@ -1,0 +1,15 @@
+<?php
+namespace Modules\MercadoPago\Models;
+
+use App\Models\NsModel;
+
+class MercadoPagoTransaction extends NsModel
+{
+    protected $table = 'nexopos_mercadopago_transactions';
+
+    protected $fillable = [
+        'payment_id',
+        'status',
+        'payload',
+    ];
+}

--- a/modules/MercadoPago/Routes/web.php
+++ b/modules/MercadoPago/Routes/web.php
@@ -1,0 +1,8 @@
+<?php
+use Illuminate\Support\Facades\Route;
+use Modules\MercadoPago\Http\Controllers\CallbackController;
+
+Route::prefix('mercadopago')->group(function () {
+    Route::post('callback', [CallbackController::class, 'handle'])
+        ->name('mercadopago.callback');
+});


### PR DESCRIPTION
## Summary
- add migration for `mercadopago_transactions`
- add MercadoPago transaction model
- handle payment notifications in `CallbackController`
- register callback route

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684763d4d544832abfe900d679c94688