### PR TITLE
Add MercadoPago database migration

### DIFF
--- a/modules/MercadoPago/Migrations/DatabaseMigration.php
+++ b/modules/MercadoPago/Migrations/DatabaseMigration.php
@@ -1,0 +1,24 @@
+<?php
+namespace Modules\MercadoPago\Migrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up()
+    {
+        Schema::create('mercado_pago_transactions', function (Blueprint $table) {
+            $table->id();
+            $table->decimal('amount', 12, 2);
+            $table->string('status')->index();
+            $table->string('transaction_id')->unique();
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('mercado_pago_transactions');
+    }
+};


### PR DESCRIPTION
## Summary
- add migrations folder and MercadoPago transactions migration

## Testing
- `php -l modules/MercadoPago/Migrations/DatabaseMigration.php` *(fails: `php` not installed)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684763dac820832aa034daa57f3c712f