### PR TITLE
Fix MercadoPago settings helper

### DIFF
--- a/modules/MercadoPago/Http/Controllers/SettingsController.php
+++ b/modules/MercadoPago/Http/Controllers/SettingsController.php
@@ -9,15 +9,15 @@ class SettingsController extends Controller
     public function index()
     {
         return view('MercadoPago::settings', [
-            'token'     => settings()->get('mercadopago_access_token'),
-            'device_id' => settings()->get('mercadopago_device_id'),
+            'token'       => ns()->option->get('mercadopago_access_token'),
+            'terminal_id' => ns()->option->get('mercadopago_terminal_id'),
         ]);
     }
 
     public function save(Request $request)
     {
-        settings()->set('mercadopago_access_token', $request->input('mercadopago_access_token'));
-        settings()->set('mercadopago_device_id', $request->input('mercadopago_device_id'));
+        ns()->option->set('mercadopago_access_token', $request->input('mercadopago_access_token'));
+        ns()->option->set('mercadopago_terminal_id', $request->input('mercadopago_terminal_id'));
 
         return redirect()->back()->with('success', __('Settings saved'));
     }

--- a/modules/MercadoPago/Payments/MercadoPagoPayment.php
+++ b/modules/MercadoPago/Payments/MercadoPagoPayment.php
@@ -18,8 +18,8 @@ class MercadoPagoPayment implements PaymentMethodInterface
 
     public function process(array $payload)
     {
-        $token  = settings()->get('mercadopago_access_token');
-        $device = settings()->get('mercadopago_device_id');
+        $token  = ns()->option->get('mercadopago_access_token');
+        $device = ns()->option->get('mercadopago_terminal_id');
 
         $response = Http::withToken($token)
             ->post("https://api.mercadopago.com/point/integration-api/devices/{$device}/orders", [

--- a/modules/MercadoPago/Resources/Views/settings.blade.php
+++ b/modules/MercadoPago/Resources/Views/settings.blade.php
@@ -3,8 +3,8 @@
     <label>{{ __('Access Token') }}</label>
     <input type="text" name="mercadopago_access_token" value="{{ $token ?? '' }}">
 
-    <label>{{ __('Device ID') }}</label>
-    <input type="text" name="mercadopago_device_id" value="{{ $device_id ?? '' }}">
+    <label>{{ __('Terminal ID') }}</label>
+    <input type="text" name="mercadopago_terminal_id" value="{{ $terminal_id ?? '' }}">
 
     <button type="submit">{{ __('Save') }}</button>
 </form>

--- a/modules/MercadoPago/config.xml
+++ b/modules/MercadoPago/config.xml
@@ -7,6 +7,6 @@
     <description>Payment integration using Mercado Pago.</description>
     <settings>
         <setting key="mercadopago_access_token"/>
-        <setting key="mercadopago_device_id"/>
+        <setting key="mercadopago_terminal_id"/>
     </settings>
 </module>


### PR DESCRIPTION
## Summary
- fix calls to undefined `settings()` helper by using `ns()->option`
- rename device ID references to terminal ID per NexoPOS docs

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68476a12bdd4832a9715386815ba1948