### PR TITLE
Add logs and implement pay endpoint for MercadoPago

### DIFF
--- a/modules/MercadoPago/Http/Controllers/MercadoPagoController.php
+++ b/modules/MercadoPago/Http/Controllers/MercadoPagoController.php
@@ -11,6 +11,9 @@ namespace Modules\MercadoPago\Http\Controllers;
 use Illuminate\Support\Facades\View;
 use App\Http\Controllers\Controller;
 use Modules\MercadoPago\Models\MercadoPagoSetting;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Modules\MercadoPago\Services\MercadoPagoGateway;
 
 
 
@@ -36,6 +39,27 @@ class MercadoPagoController extends Controller
             'token' => $setting->access_token ?? '',
             'terminal_id' => $setting->terminal_id ?? '',
             ]);
+    }
+
+    public function pay(Request $request)
+    {
+        Log::info('MercadoPagoController pay request', $request->all());
+
+        $order = $request->input('order');
+
+        if (!$order) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Order data missing',
+            ], 422);
+        }
+
+        $gateway = new MercadoPagoGateway();
+        $result = $gateway->process((object) $order);
+
+        Log::info('MercadoPagoController pay result', ['result' => $result]);
+
+        return $result;
     }
 
 }

--- a/modules/MercadoPago/Resources/ts/mercadopago-payment.vue
+++ b/modules/MercadoPago/Resources/ts/mercadopago-payment.vue
@@ -9,17 +9,23 @@ export default {
     name: 'mercadopago-payment',
     props: ['identifier', 'label'],
     components: { samplePayment },
+    mounted() {
+        console.log('MercadoPago payment component mounted');
+    },
     methods: {
         async processPayment() {
             try {
                 const order = POS.order.getValue();
+                console.log('Sending order to /api/mercadopago/pay', order);
                 const response = await nsHttpClient.post('/api/mercadopago/pay', { order }).toPromise();
+                console.log('MercadoPago pay response', response);
                 if (response.status === 'created' || response.status === 'paid') {
                     this.$emit('submit');
                 } else {
                     nsSnackBar.error(response.message || 'Payment failed').subscribe();
                 }
             } catch(e) {
+                console.error(e);
                 nsSnackBar.error(e.message || 'Payment error').subscribe();
             }
         }

--- a/modules/MercadoPago/Services/MercadoPagoGateway.php
+++ b/modules/MercadoPago/Services/MercadoPagoGateway.php
@@ -6,6 +6,7 @@ use App\Abstracts\AbstractPaymentMethod;
 use Modules\MercadoPago\Models\MercadoPagoSetting;
 use Modules\MercadoPago\Models\MercadoPagoTransaction;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 
 class MercadoPagoGateway extends AbstractPaymentMethod
 {
@@ -16,6 +17,8 @@ class MercadoPagoGateway extends AbstractPaymentMethod
 
     public function process($order)
     {
+        Log::info('MercadoPagoGateway process order', ['order' => $order]);
+
         $settings = MercadoPagoSetting::first();
 
         if (! $settings) {
@@ -41,10 +44,13 @@ class MercadoPagoGateway extends AbstractPaymentMethod
         ]);
 
         if ($response->failed()) {
+            Log::error('MercadoPagoGateway failed', ['body' => $response->body()]);
             return ns()->error('Erro ao iniciar pagamento no Mercado Pago: ' . $response->body());
         }
 
         $data = $response->json();
+
+        Log::info('MercadoPagoGateway success', ['data' => $data]);
 
         MercadoPagoTransaction::create([
             'order_id' => $order->id,


### PR DESCRIPTION
## Summary
- add console logs in MercadoPago Vue component
- log MercadoPago API calls in `PaymentController`
- log order processing in `MercadoPagoGateway`
- implement missing `pay` endpoint in `MercadoPagoController`

## Testing
- `npm test` *(fails: jest not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684878855660832a8f5c0fc4f23418b6