### PR TITLE
Add payment selection for MercadoPago

### DIFF
--- a/modules/MercadoPago/Resources/ts/mercadopago-payment.vue
+++ b/modules/MercadoPago/Resources/ts/mercadopago-payment.vue
@@ -1,14 +1,31 @@
 <template>
-    <sample-payment :identifier="identifier" :label="label" @submit="processPayment"></sample-payment>
+    <div class="h-full w-full flex flex-col">
+        <div class="p-2">
+            <select v-model="paymentType" class="w-full border rounded p-2">
+                <option value="credit_card">Cartão de Crédito</option>
+                <option value="debit_card">Cartão de Débito</option>
+                <option value="pix">PIX</option>
+            </select>
+        </div>
+        <sample-payment
+            :identifier="identifier"
+            :label="label"
+            @submit="processPayment"/>
+    </div>
 </template>
 <script>
 import samplePayment from "~/pages/dashboard/pos/payments/sample-payment.vue";
-import { nsHttpClient } from "~/bootstrap";
+import { nsHttpClient, nsSnackBar } from "~/bootstrap";
 
 export default {
     name: 'mercadopago-payment',
     props: ['identifier', 'label'],
     components: { samplePayment },
+    data() {
+        return {
+            paymentType: 'credit_card',
+        };
+    },
     mounted() {
         console.log('MercadoPago payment component mounted');
     },
@@ -16,8 +33,8 @@ export default {
         async processPayment() {
             try {
                 const order = POS.order.getValue();
-                console.log('Sending order to /api/mercadopago/pay', order);
-                const response = await nsHttpClient.post('/api/mercadopago/pay', { order }).toPromise();
+                console.log('Sending order to /api/mercadopago/pay', order, 'type', this.paymentType);
+                const response = await nsHttpClient.post('/api/mercadopago/pay', { order, payment_type: this.paymentType }).toPromise();
                 console.log('MercadoPago pay response', response);
                 if (response.status === 'created' || response.status === 'paid') {
                     this.$emit('submit');


### PR DESCRIPTION
## Summary
- enhance MercadoPago payment view with options for credit, debit and PIX

## Testing
- `npm test` *(fails: jest not found)*
- `./vendor/bin/phpunit --dont-report-useless-tests` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_68499007c20c832ab908b880eea98ec7